### PR TITLE
初期セットアップに失敗する不具合の修正など

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,6 @@ bootstrap:
 
 project:
 	mint run Carthage/Carthage carthage bootstrap --platform iOS --cache-builds
-	echo mint run Carthage/Carthage carthage update --platform iOS --cache-builds
+	echo 'mint run Carthage/Carthage carthage update --platform iOS --cache-builds'
 	mint run SwiftGen/SwiftGen swiftgen
 	mint run yonaskolb/XcodeGen xcodegen generate

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 bootstrap:
 	brew update
-	brew install carthage mint
+	brew install libxml2
+	brew install mint
 	mint bootstrap
 
 project:
-	carthage bootstrap --platform iOS --cache-builds
-	echo carthage update --platform iOS --cache-builds
-	swiftgen
-	xcodegen
+	mint run Carthage/Carthage carthage bootstrap --platform iOS --cache-builds
+	echo mint run Carthage/Carthage carthage update --platform iOS --cache-builds
+	mint run SwiftGen/SwiftGen swiftgen
+	mint run yonaskolb/XcodeGen xcodegen generate

--- a/Mintfile
+++ b/Mintfile
@@ -1,3 +1,5 @@
-yonaskolb/xcodegen
+yonaskolb/xcodegen@2.15.0
 realm/SwiftLint@0.38.0
-SwiftGen/SwiftGen
+SwiftGen/SwiftGen@6.1.0
+Carthage/Carthage@0.34.0
+

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@
 Execute these commands in your terminal with the path of this project.
 
 ```ruby
-$make bootstrap
+$ make bootstrap
 ```
 and
 ```
-$make project
+$ make project
 ```

--- a/project.yml
+++ b/project.yml
@@ -2,6 +2,7 @@ name: Pokedex
 options:
   deploymentTarget:
     iOS: 11.0
+  carthageExecutablePath: mint run Carthage/Carthage carthage
 fileGroups:
 targets:
   Pokedex:


### PR DESCRIPTION
修正内容:

- SwiftGenはlibxml2を入れないとビルドできなかった
- CarthageはSwift製のCLIなので、Mintで管理するように変更した
- Mintで管理しているCLIは、先頭に `mint run {CLI名}` を付けないと実行されない
- Mintで管理しているCLIのバージョンを固定にした  
∵Mintはロックファイルがないので、Mintfileでバージョンを指定しないと、人によってバージョンが変わってしまう

参考:

- https://github.com/SwiftGen/SwiftGen/issues/580