### PR TITLE
UserDefaultsでsynchronize()を呼び出さない様にする対応

### DIFF
--- a/DataStore/Storage/UserDefaults/DataStore/UserDefaultsDataStore.swift
+++ b/DataStore/Storage/UserDefaults/DataStore/UserDefaultsDataStore.swift
@@ -30,11 +30,9 @@ private struct UserDefaultsDataStoreImpl: UserDefaultsDataStore {
 
     func set(value: Any, key: String) {
         self.userDefaults.set(value, forKey: key)
-        self.userDefaults.synchronize()
     }
 
     func delete(key: String) {
         self.userDefaults.set(nil, forKey: key)
-        self.userDefaults.synchronize()
     }
 }


### PR DESCRIPTION
#3 での指摘による変更

[公式ドキュメント](https://developer.apple.com/documentation/foundation/nsuserdefaults/1414005-synchronize)にもsynchronize()を呼び出さない様にと書いてあった。