### PR TITLE
No.650以降のポケモン詳細画面が開けない問題の対応

### DIFF
--- a/DataStore/API/Response/PokemonDetail/PokemonDetailResponse.swift
+++ b/DataStore/API/Response/PokemonDetail/PokemonDetailResponse.swift
@@ -203,10 +203,10 @@ extension PokemonDetailResponse {
     public struct PokemonSprite: Codable {
 
         /// The default depiction of this Pokémon from the back in battle.(後ろ姿)
-        public let backDefault: String
+        public let backDefault: String?
 
         /// The shiny depiction of this Pokémon from the back in battle.(色違いの後ろ姿)
-        public let backShiny: String
+        public let backShiny: String?
 
         /// The female depiction of this Pokémon from the back in battle.(後ろ姿♀)
         public let backFemale: String?

--- a/Domain/Modules/PokemonDetail/Model/PokemonDetailModel.swift
+++ b/Domain/Modules/PokemonDetail/Model/PokemonDetailModel.swift
@@ -39,9 +39,12 @@ extension PokemonDetailModel {
         static func generate(from response: PokemonDetailResponse) -> [Segment] {
             var segments = [Segment]()
 
-            let frontImageUrl = PokemonImageURLGenerator.generate(response.id, type: .front)
-            let backImageUrl = PokemonImageURLGenerator.generate(response.id, type: .back)
-            segments.append(.init(contents: [.image(frontImageUrl: frontImageUrl, backImageUrl: backImageUrl)]))
+            let frontImageUrl = response.sprites.frontDefault
+            if let backImageUrl = response.sprites.backDefault {
+                segments.append(.init(contents: [.dualImage(frontImageUrl: frontImageUrl, backImageUrl: backImageUrl)]))
+            } else {
+                segments.append(.init(contents: [.singleImage(frontImageUrl: frontImageUrl)]))
+            }
 
             let types = response.types.sorted { $0.slot < $1.slot }.compactMap { PokemonType($0) }
             segments.append(.init(contents: [.pokemonTypes(types)]))
@@ -65,7 +68,8 @@ extension PokemonDetailModel {
 extension PokemonDetailModel.Segment {
 
     public enum Content {
-        case image(frontImageUrl: String, backImageUrl: String)
+        case singleImage(frontImageUrl: String)
+        case dualImage(frontImageUrl: String, backImageUrl: String)
         case pokemonTypes([PokemonType])
         case height(Float)
         case weight(Float)

--- a/Presentation/Modules/PokemonDetail/View/Parts/Cells/Image/PokemonDetailDualImageCell.swift
+++ b/Presentation/Modules/PokemonDetail/View/Parts/Cells/Image/PokemonDetailDualImageCell.swift
@@ -1,5 +1,5 @@
 //
-//  PokemonDetailImageCell.swift
+//  PokemonDetailDualImageCell.swift
 //  Presentation
 //
 //  Created by Tomosuke Okada on 2020/03/20.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class PokemonDetailImageCell: UITableViewCell {
+final class PokemonDetailDualImageCell: UITableViewCell {
 
     @IBOutlet private weak var frontImageView: UIImageView!
     @IBOutlet private weak var backImageView: UIImageView!

--- a/Presentation/Modules/PokemonDetail/View/Parts/Cells/Image/PokemonDetailDualImageCell.xib
+++ b/Presentation/Modules/PokemonDetail/View/Parts/Cells/Image/PokemonDetailDualImageCell.xib
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="227" id="KGk-i7-Jjw" customClass="PokemonDetailImageCell" customModule="Presentation" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="227" id="KGk-i7-Jjw" customClass="PokemonDetailDualImageCell" customModule="Presentation" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="227"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">

--- a/Presentation/Modules/PokemonDetail/View/Parts/Cells/SingleImage/PokemonDetailSingleImageCell.swift
+++ b/Presentation/Modules/PokemonDetail/View/Parts/Cells/SingleImage/PokemonDetailSingleImageCell.swift
@@ -1,0 +1,17 @@
+//
+//  PokemonDetailSingleImageCell.swift
+//  Presentation
+//
+//  Created by Tomosuke Okada on 2020/04/04.
+//
+
+import UIKit
+
+final class PokemonDetailSingleImageCell: UITableViewCell {
+
+    @IBOutlet private weak var frontImageView: UIImageView!
+
+    func setData(_ frontImageUrl: String) {
+        self.frontImageView.loadImage(with: frontImageUrl)
+    }
+}

--- a/Presentation/Modules/PokemonDetail/View/Parts/Cells/SingleImage/PokemonDetailSingleImageCell.xib
+++ b/Presentation/Modules/PokemonDetail/View/Parts/Cells/SingleImage/PokemonDetailSingleImageCell.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="227" id="S9e-ch-NIu" customClass="PokemonDetailSingleImageCell" customModule="Presentation" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="192"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="S9e-ch-NIu" id="uFX-ri-X9d">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="192"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cxW-ao-lPe">
+                        <rect key="frame" x="80" y="16" width="160" height="160"/>
+                        <constraints>
+                            <constraint firstAttribute="width" secondItem="cxW-ao-lPe" secondAttribute="height" multiplier="1:1" id="L5i-bp-pcB"/>
+                        </constraints>
+                    </imageView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="cxW-ao-lPe" firstAttribute="centerY" secondItem="uFX-ri-X9d" secondAttribute="centerY" id="O6k-LQ-aDU"/>
+                    <constraint firstItem="cxW-ao-lPe" firstAttribute="width" secondItem="uFX-ri-X9d" secondAttribute="width" multiplier="0.5" id="VoV-1o-aoT"/>
+                    <constraint firstAttribute="bottom" secondItem="cxW-ao-lPe" secondAttribute="bottom" constant="16" id="XUz-At-rAF"/>
+                    <constraint firstItem="cxW-ao-lPe" firstAttribute="top" secondItem="uFX-ri-X9d" secondAttribute="top" constant="16" id="fdT-Sa-LDz"/>
+                    <constraint firstItem="cxW-ao-lPe" firstAttribute="centerX" secondItem="uFX-ri-X9d" secondAttribute="centerX" id="gjm-ad-20c"/>
+                </constraints>
+            </tableViewCellContentView>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <connections>
+                <outlet property="frontImageView" destination="cxW-ao-lPe" id="wqH-t4-KJB"/>
+            </connections>
+            <point key="canvasLocation" x="140.57971014492756" y="183.81696428571428"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Presentation/Modules/PokemonDetail/View/Parts/PokemonDetailModel+.swift
+++ b/Presentation/Modules/PokemonDetail/View/Parts/PokemonDetailModel+.swift
@@ -12,7 +12,8 @@ extension PokemonDetailModel.Segment.Content {
 
     static var allCellType: [UITableViewCell.Type] {
         return [
-            PokemonDetailImageCell.self,
+            PokemonDetailSingleImageCell.self,
+            PokemonDetailDualImageCell.self,
             PokemonDetailPokemonTypeCell.self,
             PokemonDetailHeightCell.self,
             PokemonDetailWeightCell.self,
@@ -22,8 +23,10 @@ extension PokemonDetailModel.Segment.Content {
 
     var cellType: UITableViewCell.Type {
         switch self {
-        case .image:
-            return PokemonDetailImageCell.self
+        case .singleImage:
+            return PokemonDetailSingleImageCell.self
+        case .dualImage:
+            return PokemonDetailDualImageCell.self
         case .pokemonTypes:
             return PokemonDetailPokemonTypeCell.self
         case .height:

--- a/Presentation/Modules/PokemonDetail/View/PokemonDetailViewController.swift
+++ b/Presentation/Modules/PokemonDetail/View/PokemonDetailViewController.swift
@@ -77,8 +77,10 @@ extension PokemonDetailViewController: UITableViewDataSource {
         let content = self.segments[indexPath.section].contents[indexPath.row]
         let cell = tableView.dequeueReusableCell(withIdentifier: content.cellType.className, for: indexPath)
         switch self.segments[indexPath.section].contents[indexPath.row] {
-        case .image(let frontImageUrl, let backImageUrl):
-            (cell as! PokemonDetailImageCell).setData(frontImageUrl: frontImageUrl, backImageUrl: backImageUrl)
+        case .singleImage(let frontImageUrl):
+            (cell as! PokemonDetailSingleImageCell).setData(frontImageUrl)
+        case .dualImage(let frontImageUrl, let backImageUrl):
+            (cell as! PokemonDetailDualImageCell).setData(frontImageUrl: frontImageUrl, backImageUrl: backImageUrl)
         case .pokemonTypes(let types):
             (cell as! PokemonDetailPokemonTypeCell).setData(types)
         case .height(let height):


### PR DESCRIPTION
#5 の問題の対応
No.650以降のポケモンのレスポンスには、背面画像のURLがnullで返却されるため、レスポンスでOptionalを受け付ける様に変更し、背面画像のURLがnullだった場合は表示を切り替える様に変更した。

今回追加した前面画像のみのパターン
<img src="https://user-images.githubusercontent.com/20692907/78424759-a1d79700-76aa-11ea-87c7-0cada754812b.png" width="200">

既存の前面、背面両方存在するパターンは変更なし
<img src="https://user-images.githubusercontent.com/20692907/78424760-a56b1e00-76aa-11ea-89d7-057d53ba7630.png" width="200">
