### PR TITLE
ポケモン詳細画面の種族値をカラーバーで表示する

### DIFF
--- a/Domain/DomainModel/Status/PokemonStatus.swift
+++ b/Domain/DomainModel/Status/PokemonStatus.swift
@@ -51,6 +51,23 @@ extension PokemonStatus {
             }
         }
 
+        var priority: Int {
+            switch self {
+            case .hp:
+                return 0
+            case .attack:
+                return 1
+            case .defense:
+                return 2
+            case .specialAttack:
+                return 3
+            case .specialDefense:
+                return 4
+            case .speed:
+                return 5
+            }
+        }
+
         public var text: String {
             switch self {
             case .hp:
@@ -68,20 +85,20 @@ extension PokemonStatus {
             }
         }
 
-        var priority: Int {
+        public var hex: String {
             switch self {
             case .hp:
-                return 0
+                return "1DD1A1"
             case .attack:
-                return 1
+                return "EE5253"
             case .defense:
-                return 2
+                return "0ABDE3"
             case .specialAttack:
-                return 3
+                return "FF9F43"
             case .specialDefense:
-                return 4
+                return "5F27CD"
             case .speed:
-                return 5
+                return "48DBFB"
             }
         }
     }

--- a/Domain/Modules/PokemonDetail/Model/PokemonDetailModel.swift
+++ b/Domain/Modules/PokemonDetail/Model/PokemonDetailModel.swift
@@ -39,6 +39,7 @@ extension PokemonDetailModel {
         static func generate(from response: PokemonDetailResponse) -> [Segment] {
             var segments = [Segment]()
 
+            // Image
             let frontImageUrl = response.sprites.frontDefault
             if let backImageUrl = response.sprites.backDefault {
                 segments.append(.init(contents: [.dualImage(frontImageUrl: frontImageUrl, backImageUrl: backImageUrl)]))
@@ -46,16 +47,18 @@ extension PokemonDetailModel {
                 segments.append(.init(contents: [.singleImage(frontImageUrl: frontImageUrl)]))
             }
 
+            // Type
             let types = response.types.sorted { $0.slot < $1.slot }.compactMap { PokemonType($0) }
             segments.append(.init(contents: [.pokemonTypes(types)]))
 
+            // Body
             // dm -> m
             let mHeight = Float(response.height) / 10
             // hg -> kg
             let kgWeight = Float(response.weight) / 10
-
             segments.append(.init(contents: [.height(mHeight), .weight(kgWeight)]))
 
+            // Status
             let stats = response.stats.compactMap { PokemonStatus(name: $0.stat.name, value: $0.baseStat) }
             let sortedStats = stats.sorted { $0.type.priority < $1.type.priority }
             segments.append(.init(contents: sortedStats.map { Content.status($0) }))

--- a/Presentation/Custom/PokemonStatusView/PokemonStatusView.swift
+++ b/Presentation/Custom/PokemonStatusView/PokemonStatusView.swift
@@ -1,0 +1,28 @@
+//
+//  PokemonStatusView.swift
+//  Presentation
+//
+//  Created by Tomosuke Okada on 2020/04/09.
+//
+
+import Domain
+import UIKit
+
+final class PokemonStatusView: XibLoadableView {
+
+    @IBOutlet private weak var valueLabel: UILabel!
+
+    @IBOutlet private weak var statusBarView: UIView!
+
+    private var statusBarWidthConstraint: NSLayoutConstraint?
+
+    func setData(_ status: PokemonStatus) {
+        self.valueLabel.text = "\(status.value)"
+        self.statusBarView.backgroundColor = UIColor(hex: status.type.hex)
+
+        self.statusBarWidthConstraint?.isActive = false
+        let multiplier = CGFloat(status.value) / 255
+        self.statusBarWidthConstraint = self.statusBarView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: multiplier)
+        self.statusBarWidthConstraint?.isActive = true
+    }
+}

--- a/Presentation/Custom/PokemonStatusView/PokemonStatusView.xib
+++ b/Presentation/Custom/PokemonStatusView/PokemonStatusView.xib
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PokemonStatusView" customModule="Presentation" customModuleProvider="target">
+            <connections>
+                <outlet property="statusBarView" destination="3nY-8T-t5B" id="iFp-xy-iUD"/>
+                <outlet property="valueLabel" destination="0Oi-Np-gbh" id="jcv-WV-BGs"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="60"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" placeholderIntrinsicWidth="414" placeholderIntrinsicHeight="60" translatesAutoresizingMaskIntoConstraints="NO" id="3nY-8T-t5B">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="60"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </view>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Oi-Np-gbh">
+                    <rect key="frame" x="16" y="0.0" width="382" height="60"/>
+                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="3nY-8T-t5B" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="O5O-Uf-9MY"/>
+                <constraint firstItem="0Oi-Np-gbh" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="WxR-XR-Tcn"/>
+                <constraint firstItem="3nY-8T-t5B" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="X2J-Fa-ugs"/>
+                <constraint firstAttribute="bottom" secondItem="3nY-8T-t5B" secondAttribute="bottom" id="Xl4-r3-4Di"/>
+                <constraint firstAttribute="trailing" secondItem="0Oi-Np-gbh" secondAttribute="trailing" constant="16" id="ezU-e1-llV"/>
+                <constraint firstItem="0Oi-Np-gbh" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="o2v-I6-9aF"/>
+                <constraint firstAttribute="bottom" secondItem="0Oi-Np-gbh" secondAttribute="bottom" id="oyz-Jh-Zd3"/>
+                <constraint firstItem="0Oi-Np-gbh" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="uLr-Iu-12w"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="139" y="154"/>
+        </view>
+    </objects>
+</document>

--- a/Presentation/Modules/PokemonDetail/View/Parts/Cells/Status/PokemonDetailStatusCell.swift
+++ b/Presentation/Modules/PokemonDetail/View/Parts/Cells/Status/PokemonDetailStatusCell.swift
@@ -12,10 +12,10 @@ final class PokemonDetailStatusCell: UITableViewCell {
 
     @IBOutlet private weak var nameLabel: UILabel!
 
-    @IBOutlet private weak var valueLabel: UILabel!
+    @IBOutlet private weak var statusView: PokemonStatusView!
 
     func setData(_ status: PokemonStatus) {
         self.nameLabel.text = status.type.text
-        self.valueLabel.text = "\(status.value)"
+        self.statusView.setData(status)
     }
 }

--- a/Presentation/Modules/PokemonDetail/View/Parts/Cells/Status/PokemonDetailStatusCell.xib
+++ b/Presentation/Modules/PokemonDetail/View/Parts/Cells/Status/PokemonDetailStatusCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,12 +16,6 @@
                 <rect key="frame" x="0.0" y="0.0" width="414" height="68"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iAB-Rw-vib">
-                        <rect key="frame" x="96" y="25" width="302" height="18"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Defense" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j8x-4e-445">
                         <rect key="frame" x="16" y="24.5" width="70" height="19.5"/>
                         <constraints>
@@ -31,18 +25,25 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Arj-00-mcE" customClass="PokemonStatusView" customModule="Presentation" customModuleProvider="target">
+                        <rect key="frame" x="96" y="19" width="302" height="30"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="30" id="pz0-Gu-cs0"/>
+                        </constraints>
+                    </view>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailing" secondItem="iAB-Rw-vib" secondAttribute="trailing" constant="16" id="9oo-xn-x0w"/>
-                    <constraint firstItem="iAB-Rw-vib" firstAttribute="centerY" secondItem="Oaa-rY-Z5d" secondAttribute="centerY" id="IJL-bR-dxB"/>
+                    <constraint firstItem="Arj-00-mcE" firstAttribute="centerY" secondItem="Oaa-rY-Z5d" secondAttribute="centerY" id="HDx-YU-2dH"/>
                     <constraint firstItem="j8x-4e-445" firstAttribute="centerY" secondItem="Oaa-rY-Z5d" secondAttribute="centerY" id="KXz-Zn-nak"/>
                     <constraint firstItem="j8x-4e-445" firstAttribute="leading" secondItem="Oaa-rY-Z5d" secondAttribute="leading" constant="16" id="RmN-cK-7PY"/>
-                    <constraint firstItem="iAB-Rw-vib" firstAttribute="leading" secondItem="j8x-4e-445" secondAttribute="trailing" constant="10" id="XDp-vO-2gL"/>
+                    <constraint firstItem="Arj-00-mcE" firstAttribute="leading" secondItem="j8x-4e-445" secondAttribute="trailing" constant="10" id="Wdz-ab-JfS"/>
+                    <constraint firstAttribute="trailing" secondItem="Arj-00-mcE" secondAttribute="trailing" constant="16" id="cKy-oh-IX3"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
                 <outlet property="nameLabel" destination="j8x-4e-445" id="rIH-9o-JZQ"/>
-                <outlet property="valueLabel" destination="iAB-Rw-vib" id="MHM-7d-esw"/>
+                <outlet property="statusView" destination="Arj-00-mcE" id="8Nl-Ig-eqe"/>
             </connections>
             <point key="canvasLocation" x="137.68115942028987" y="140.625"/>
         </tableViewCell>


### PR DESCRIPTION
#9 による対応

種族値の表示を数値のみでなく、最大値の255を元に割合でカラーバーとして表示する。

スクリーンショットは最大値と最小値になった際の表示した際の例

ハピナス(HP255)
<img src="https://user-images.githubusercontent.com/20692907/78913130-806c1600-7ac3-11ea-8b5e-d0fcc492c7b0.png" width="200">

ヌケニン(HP1)
<img src="https://user-images.githubusercontent.com/20692907/78913135-8235d980-7ac3-11ea-978f-7ce041f524b4.png" width="200">
