### PR TITLE
画像をpokemon.jsonから取得する変更

### DIFF
--- a/DataStore/API/Response/PokemonDetail/PokemonDetailResponse.swift
+++ b/DataStore/API/Response/PokemonDetail/PokemonDetailResponse.swift
@@ -215,10 +215,10 @@ extension PokemonDetailResponse {
         public let backShinyFemale: String?
 
         /// The default depiction of this Pokémon from the front in battle.(正面)
-        public let frontDefault: String
+        public let frontDefault: String?
 
         /// The shiny depiction of this Pokémon from the front in battle.(色違いの正面)
-        public let frontShiny: String
+        public let frontShiny: String?
 
         /// The female depiction of this Pokémon from the front in battle.(正面♀)
         public let frontFemale: String?

--- a/Domain/Modules/PokemonDetail/Model/PokemonDetailModel.swift
+++ b/Domain/Modules/PokemonDetail/Model/PokemonDetailModel.swift
@@ -25,7 +25,7 @@ public struct PokemonDetailModel {
     init(_ response: PokemonDetailResponse) {
         self.number = response.id
         self.name = response.name
-        self.imageUrl = response.sprites.frontDefault
+        self.imageUrl = PokemonImageURLGenerator.generate(from: response.id)
         self.typeHex = response.types.sorted { $0.slot < $1.slot }.compactMap { PokemonType($0) }.first?.hex ?? ""
         self.information = Information(response)
         self.stats = response.stats.compactMap { PokemonStatus(name: $0.stat.name, value: $0.baseStat) }.sorted { $0.type.priority < $1.type.priority }

--- a/Domain/Modules/PokemonList/Model/PokemonListModel.swift
+++ b/Domain/Modules/PokemonList/Model/PokemonListModel.swift
@@ -19,7 +19,7 @@ extension PokemonListModel {
 
     init(_ response: PokemonListResponse) {
         self.count = response.count
-        self.pokemons = response.results.enumerated().map { Pokemon($0.element, offset: $0.offset) }
+        self.pokemons = response.results.map { Pokemon($0) }
     }
 }
 
@@ -36,9 +36,9 @@ extension PokemonListModel {
 
 extension PokemonListModel.Pokemon {
 
-    init(_ pokemon: PokemonListResponse.Result, offset: Int) {
+    init(_ pokemon: PokemonListResponse.Result) {
         self.name = pokemon.name
-        self.number = offset + 1
-        self.imageUrl = PokemonImageURLGenerator.generate(self.number, type: .front)
+        self.number = PokemonNumberGenerator.generate(from: pokemon.url)
+        self.imageUrl = PokemonImageURLGenerator.generate(from: self.number)
     }
 }

--- a/Domain/Utility/Image/PokemonImageURLGenerator.swift
+++ b/Domain/Utility/Image/PokemonImageURLGenerator.swift
@@ -9,25 +9,10 @@ import Foundation
 
 enum PokemonImageURLGenerator {
 
-    static func generate(_ id: Int, type: Type) -> String {
-        return type.generate(from: id)
-    }
-}
-
-extension PokemonImageURLGenerator {
-
-    enum `Type` {
-        case front
-        case back
-
-        func generate(from id: Int) -> String {
-            let baseURL: String = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/"
-            switch self {
-            case .front:
-                return "\(baseURL)\(id).png"
-            case .back:
-                return "\(baseURL)back/\(id).png"
-            }
-        }
+    static func generate(from id: Int) -> String {
+        // 3桁0埋め文字列生成
+        let formatId = String(format: "%03d", id)
+        let imageUrl = "https://raw.githubusercontent.com/fanzeyi/pokemon.json/master/images/\(formatId).png"
+        return imageUrl
     }
 }

--- a/Domain/Utility/Number/PokemonNumberGenerator.swift
+++ b/Domain/Utility/Number/PokemonNumberGenerator.swift
@@ -1,0 +1,17 @@
+//
+//  PokemonNumberGenerator.swift
+//  Domain
+//
+//  Created by Tomosuke Okada on 2020/04/29.
+//
+
+import Foundation
+
+enum PokemonNumberGenerator {
+
+    static func generate(from url: String) -> Int {
+        var removePrefix = url.replacingOccurrences(of: "https://pokeapi.co/api/v2/pokemon/", with: "")
+        removePrefix.removeLast()
+        return Int(removePrefix) ?? 0
+    }
+}

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 - PokemonList
 
-<img src="https://user-images.githubusercontent.com/20692907/79763119-9a78e480-835e-11ea-9e20-1816672632fd.png" width="250">
+<img src="https://user-images.githubusercontent.com/20692907/80538716-29ca6b80-89e1-11ea-935b-48a0e6736315.png" width="250">
 
 - PokemonDetail
 
-<img src="https://user-images.githubusercontent.com/20692907/79763126-9cdb3e80-835e-11ea-871e-c5889eeebfa7.png" width="250">
+<img src="https://user-images.githubusercontent.com/20692907/80538722-2b942f00-89e1-11ea-82a6-dd90adde8bd7.png" width="250">
 
-<img src="https://user-images.githubusercontent.com/20692907/79766430-f04f8b80-8362-11ea-88fc-1bcc182fcd3c.png" width="250">
+<img src="https://user-images.githubusercontent.com/20692907/80539155-fd631f00-89e1-11ea-8ed9-0143bf7fbc0f.png" width="250">
 
 # Demo
-<img src="https://user-images.githubusercontent.com/20692907/79763116-977df400-835e-11ea-93c9-e2bc04d89b8a.gif" width="250">
+<img src="https://user-images.githubusercontent.com/20692907/80539441-75314980-89e2-11ea-81f8-7b6661d6495e.gif" width="250">
 
 # Requirements
 - Xcode11.4+

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@
 ## API
 - [PokéAPI](https://pokeapi.co/)
 
+## Image Resource
+- [pokemon.json](https://github.com/fanzeyi/pokemon.json)
+
 ## Tools
 - [SwiftGen](https://github.com/SwiftGen/SwiftGen)
 - [SwiftLint](https://github.com/realm/SwiftLint)


### PR DESCRIPTION
PokéAPIでは、小さいドット絵の画像しか取得できないので、pokemon.jsonからイラスト画像を取得する様に変更した

一覧
<img src="https://user-images.githubusercontent.com/20692907/80538716-29ca6b80-89e1-11ea-935b-48a0e6736315.png" width="250">

詳細
<img src="https://user-images.githubusercontent.com/20692907/80538722-2b942f00-89e1-11ea-82a6-dd90adde8bd7.png" width="250">