### PR TITLE
CI環境の構築

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+    paths-ignore:
+      - Templates/**
+      - README.md
+      - LICENSE
+      - Rambafile
+  pull_request:
+    branches:
+      - develop
+    paths-ignore:
+      - Templates/**
+      - README.md
+      - LICENSE
+      - Rambafile
+
+env:
+  DEVELOPER_DIR: /Applications/Xcode_11.4.1.app/Contents/Developer
+
+jobs:
+  test:
+    runs-on: macOS-latest
+    env:
+      MINT_PATH: mint/lib
+      MINT_LINK_PATH: mint/bin
+
+    steps:
+    # チェックアウト
+    - uses: actions/checkout@v2
+
+    # Xcodeの一覧出力
+    - name: Show Xcode list
+      run: ls /Applications | grep 'Xcode'
+
+    # Xcodeのバージョン出力
+    - name: Show Xcode version
+      run: xcodebuild -version
+
+    # Mintで管理しているライブラリのキャッシュ復元
+    - name: Cache Mint packages
+      uses: actions/cache@v1
+      with:
+        path: mint
+        key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
+        restore-keys: |
+          ${{ runner.os }}-mint-
+
+    # Carthageで管理しているライブラリのキャッシュ復元
+    - name: Cache Carthage packages
+      uses: actions/cache@v1
+      with:
+        path: Carthage
+        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-carthage-
+          
+    # ブートストラップ
+    - run: make bootstrap
+
+    # プロジェクト
+    - run: make project
+      env:
+        GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # ビルド
+    - name: Xcode build
+      run: make build-debug
+
+    # 端末の一覧出力
+    - name: Show devices
+      run: make show-devices
+
+    # 単体テストの実行
+    - name: Xcode test
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TEST_SDK := iphonesimulator
 TEST_CONFIGURATION := Debug
 TEST_PLATFORM := iOS Simulator
 TEST_DEVICE ?= iPhone 11 Pro Max
-TEST_OS ?= 13.3
+TEST_OS ?= 13.4.1
 TEST_DESTINATION := 'platform=${TEST_PLATFORM},name=${TEST_DEVICE},OS=${TEST_OS}'
 
 .PHONY: bootstrap

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
+.PHONY: bootstrap
 bootstrap:
 	brew update
 	brew install libxml2
 	brew install mint
 	mint bootstrap
 
+.PHONY: project
 project:
 	mint run Carthage/Carthage carthage bootstrap --platform iOS --cache-builds
 	echo 'mint run Carthage/Carthage carthage update --platform iOS --cache-builds'

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PRODUCT_NAME := Pokedex
+
 .PHONY: bootstrap
 bootstrap:
 	brew update
@@ -11,3 +13,9 @@ project:
 	echo 'mint run Carthage/Carthage carthage update --platform iOS --cache-builds'
 	mint run SwiftGen/SwiftGen swiftgen
 	mint run yonaskolb/XcodeGen xcodegen generate
+
+.PHONY: open
+open:
+	open ./${PRODUCT_NAME}.xcodeproj
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
 PRODUCT_NAME := Pokedex
+SCHEME_NAME := ${PRODUCT_NAME}
+PROJECT_NAME := ${PRODUCT_NAME}.xcodeproj
+UI_TESTS_TARGET_NAME := ${PRODUCT_NAME}UITests
+
+TEST_SDK := iphonesimulator
+TEST_CONFIGURATION := Debug
+TEST_PLATFORM := iOS Simulator
+TEST_DEVICE ?= iPhone 11 Pro Max
+TEST_OS ?= 13.3
+TEST_DESTINATION := 'platform=${TEST_PLATFORM},name=${TEST_DEVICE},OS=${TEST_OS}'
 
 .PHONY: bootstrap
 bootstrap:
@@ -16,6 +26,33 @@ project:
 
 .PHONY: open
 open:
-	open ./${PRODUCT_NAME}.xcodeproj
+	open ./${PROJECT_NAME}
 
+.PHONY: show-devices
+show-devices:
+	instruments -s devices
+
+.PHONY: build-debug
+build-debug:
+	set -o pipefail && \
+xcodebuild \
+-sdk ${TEST_SDK} \
+-configuration ${TEST_CONFIGURATION} \
+-project ${PROJECT_NAME} \
+-scheme ${SCHEME_NAME} \
+build \
+| xcpretty
+
+.PHONY: test
+test:
+	set -o pipefail && \
+xcodebuild \
+-sdk ${TEST_SDK} \
+-configuration ${TEST_CONFIGURATION} \
+-project ${PROJECT_NAME} \
+-scheme ${SCHEME_NAME} \
+-destination ${TEST_DESTINATION} \
+-skip-testing:${UI_TESTS_TARGET_NAME} \
+clean test \
+| xcpretty
 

--- a/Pokedex.xcodeproj/xcshareddata/xcschemes/Pokedex.xcscheme
+++ b/Pokedex.xcodeproj/xcshareddata/xcschemes/Pokedex.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "799FB0F2246F9409003CFA6A"
+               BuildableName = "PokedexTests.xctest"
+               BlueprintName = "PokedexTests"
+               ReferencedContainer = "container:Pokedex.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/PokedexTests/Info.plist
+++ b/PokedexTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/PokedexTests/PokedexTests.swift
+++ b/PokedexTests/PokedexTests.swift
@@ -1,0 +1,32 @@
+//
+//  PokedexTests.swift
+//  PokedexTests
+//
+//  Created by uhooi on 2020/05/16.
+//
+
+import XCTest
+
+final class PokedexTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![1c503524c8ea1f989a82bd45e394d926](https://user-images.githubusercontent.com/20692907/78142386-d6a7dc00-7467-11ea-81ca-c21b6b77d823.png)
 
+[![](https://github.com/Frog-Frog/Pokedex/workflows/CI/badge.svg)](https://github.com/Frog-Frog/Pokedex/actions?query=workflow%3ACI)
+
 # Screenshot
 
 - PokemonList

--- a/project.yml
+++ b/project.yml
@@ -55,3 +55,13 @@ targets:
       CODE_SIGN_STYLE: Automatic
     dependencies:
       - target: DataStore
+  PokedexTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - PokedexTests
+    settings:
+      base:
+        INFOPLIST_FILE: PokedexTests/Info.plist
+    dependencies:
+      - target: Pokedex


### PR DESCRIPTION
## やったこと

- Git-flowモデルを想定し、 `master` `develop` ブランチへのプッシュ時と `develop` ブランチへのPR作成・更新時に、ビルドと単体テストを実行するCIを構築  
`feature/**` ブランチへのプッシュもトリガーにすると、 `develop` ブランチへPRを出したときにCIが2回実行されてしまうため、設定していない  
早めに `feature` ブランチでCIを実行したい場合、先にPRを作成する運用にする
- CIのYAMLファイルを簡潔にするため、 `Makefile` に `build-debug` `test` `show-devices` を追加  
現状だと1端末でしかテストを実行していないので、様々な端末やOSで行いたい場合は、GitHub Actionsの `jobs.<job_id>.strategy.matrix` を使うと実現できる  
ref: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
- 単体テストが成功するか確認するため、テストターゲットとサンプルのテストコードを追加  
不要なら削除してください
- ついでに `make open` コマンドも追加  
実行するとPokedexがXcodeで開く